### PR TITLE
#50555 fix socket-error flag for bsdutils 2.20

### DIFF
--- a/plugins/check_syslog
+++ b/plugins/check_syslog
@@ -18,7 +18,13 @@
 set -e -o pipefail -o nounset
 msg='Syslog test'
 
-if ! timeout 5 logger -i -t $0 -d -p local0.alert --socket-errors=on $msg 2>&1
+SOCKET_ERROR='--socket-errors=on'
+if dpkg -l bsdutils | grep -qF '2.20'
+then
+    SOCKET_ERROR=''
+fi
+
+if ! timeout 5 logger -i -t $0 -d -p local0.alert $SOCKET_ERROR $msg 2>&1
 then
     exit 2
 fi

--- a/plugins/check_syslog
+++ b/plugins/check_syslog
@@ -18,13 +18,13 @@
 set -e -o pipefail -o nounset
 msg='Syslog test'
 
-SOCKET_ERROR='--socket-errors=on'
+socket_error='--socket-errors=on'
 if dpkg -l bsdutils | grep -qF '2.20'
 then
     SOCKET_ERROR=''
 fi
 
-if ! timeout 5 logger -i -t $0 -d -p local0.alert $SOCKET_ERROR $msg 2>&1
+if ! timeout 5 logger -i -t $0 -d -p local0.alert "$socket_error" $msg 2>&1
 then
     exit 2
 fi


### PR DESCRIPTION
The --socket-errors flag doesn't exist on bsdutils 2.20 version.