### PR TITLE
#47990 check_df check for used inodes

### DIFF
--- a/plugins/check_df
+++ b/plugins/check_df
@@ -38,7 +38,7 @@ fi
 (
     # Fetch blocks information
     df -PlTh
-
+    
     # Fetch inodes information
     echo 'INODES'
     df -PlThi
@@ -47,46 +47,46 @@ do
     # Check if mount point exists
     if [ "$fs" = 'Filesystem' ]
     then
-	continue
+        continue
     fi
-
+    
     if [ "$fs" = 'INODES' ]
     then
-	units=' inodes'
-	continue
+        units=' inodes'
+        continue
     fi
-
+    
     # Check if we are in the an excluded path
     for excluded_path in $excluded_paths
     do
-	if echo $mount_point | grep -qE "^$excluded_path"
-	then
-	    continue 2
-	fi
+        if echo $mount_point | grep -qE "^$excluded_path"
+        then
+            continue 2
+        fi
     done
-
+    
     # Check if disk usage has triggered critical threshold. We use awk because
     # it supports comparing floats. Bash only supports integers.
     percentage=${percentage%\%}
     if awk \
-	-vpercentage="$percentage" \
-	-vcritical_threshold="$critical_threshold" \
-	'BEGIN{exit (percentage >= critical_threshold) ? 0 : 1 }'
+    -vpercentage="$percentage" \
+    -vcritical_threshold="$critical_threshold" \
+    'BEGIN{exit (percentage >= critical_threshold) ? 0 : 1 }'
     then
-	echo -n "$mount_point is ${percentage}% full, "
-	echo "$available$units available. "
-	exit 2
+        echo -n "$mount_point is ${percentage}% full, "
+        echo "$available$units available. "
+        exit 2
     fi
-
+    
     # Check if disk usage has triggered warning threshold
     if awk \
-	-vpercentage="$percentage" \
-	-vwarning_threshold="$warning_threshold" \
-	'BEGIN{exit (percentage >= warning_threshold) ? 0 : 1 }'
+    -vpercentage="$percentage" \
+    -vwarning_threshold="$warning_threshold" \
+    'BEGIN{exit (percentage >= warning_threshold) ? 0 : 1 }'
     then
-	echo -n "$mount_point is ${percentage}% full, "
-	echo "$available$units available. "
-	exit 1
+        echo -n "$mount_point is ${percentage}% full, "
+        echo "$available$units available. "
+        exit 1
     fi
 done
 

--- a/plugins/check_df
+++ b/plugins/check_df
@@ -75,7 +75,7 @@ function check_critical_threshold {
 
 function filesystem_loop {
     (
-        $1 $2
+        $1
     ) | while read fs type size used available percentage mount_point
     do
         # Check if mount point exists
@@ -98,7 +98,7 @@ function filesystem_loop {
         check_critical_threshold
         check_warning_threshold
 
-        if [ ! -z ${3+x} ]
+        if [ ! -z ${2+x} ]
         then
             check_inodes
         fi
@@ -111,8 +111,8 @@ function main {
     local display_free_space='df -PlTh'
     local display_free_inodes='df -PlTi'
 
-    filesystem_loop $display_free_space
-    filesystem_loop $display_free_inodes inodes
+    filesystem_loop "$display_free_space"
+    filesystem_loop "$display_free_inodes" inodes
 
     echo 'OK'
     exit 0

--- a/plugins/check_df
+++ b/plugins/check_df
@@ -20,65 +20,36 @@ export LC_ALL=C
 
 warning_threshold=$1
 critical_threshold=$2
-shift 2
+warning_inodes_threshold=${3:-20000000}
+shift 3
 excluded_paths=$*
 units='B'
 
 set -e -o pipefail -u
 
-if [ -z "$warning_threshold" -o -z "$critical_threshold" ]
-then
-    echo "$0: too few argument" >&2
-    echo "Usage: $0 WARN_THRESHOLD CRITICAL_THRESHOLD [EXCLUDED_PATH [EXCLUDED_PATH [...]]]" >&2
-    echo "Example: $0 80 90" >&2
-    echo "Example: $0 80 90 /var/lib/lxc" >&2
-    exit 1
-fi
+function check_params {
+    if [ -z "$warning_threshold" -o -z "$critical_threshold" ]
+    then
+        echo "$0: too few argument" >&2
+        echo "Usage: $0 WARN_THRESHOLD CRITICAL_THRESHOLD [WARN_INODES_THRESHOLD] [EXCLUDED_PATH [EXCLUDED_PATH [...]]]" >&2
+        echo "Example: $0 80 90" >&2
+        echo "Example: $0 80 90 20000000 /var/lib/lxc" >&2
+        exit 1
+    fi
+}
 
-(
-    # Fetch blocks information
-    df -PlTh
-    
-    # Fetch inodes information
-    echo 'INODES'
-    df -PlThi
-) | while read fs type size used available percentage mount_point
-do
-    # Check if mount point exists
-    if [ "$fs" = 'Filesystem' ]
-    then
-        continue
-    fi
-    
-    if [ "$fs" = 'INODES' ]
-    then
-        units=' inodes'
-        continue
-    fi
-    
-    # Check if we are in the an excluded path
-    for excluded_path in $excluded_paths
-    do
-        if echo $mount_point | grep -qE "^$excluded_path"
-        then
-            continue 2
-        fi
-    done
-    
-    # Check if disk usage has triggered critical threshold. We use awk because
-    # it supports comparing floats. Bash only supports integers.
-    percentage=${percentage%\%}
+function check_inodes {
     if awk \
-    -vpercentage="$percentage" \
-    -vcritical_threshold="$critical_threshold" \
-    'BEGIN{exit (percentage >= critical_threshold) ? 0 : 1 }'
+    -vused="$used" \
+    -vwarning_inodes_threshold="$warning_inodes_threshold" \
+    'BEGIN{exit (used >= warning_inodes_threshold) ? 0 : 1 }'
     then
-        echo -n "$mount_point is ${percentage}% full, "
-        echo "$available$units available. "
+        echo "$mount_point has more than ${warning_inodes_threshold} inodes"
         exit 2
     fi
-    
-    # Check if disk usage has triggered warning threshold
+}
+
+function check_warning_threshold {
     if awk \
     -vpercentage="$percentage" \
     -vwarning_threshold="$warning_threshold" \
@@ -88,7 +59,63 @@ do
         echo "$available$units available. "
         exit 1
     fi
-done
+}
 
-echo 'OK'
-exit 0
+function check_critical_threshold {
+    if awk \
+    -vpercentage="$percentage" \
+    -vcritical_threshold="$critical_threshold" \
+    'BEGIN{exit (percentage >= critical_threshold) ? 0 : 1 }'
+    then
+        echo -n "$mount_point is ${percentage}% full, "
+        echo "$available$units available. "
+        exit 2
+    fi
+}
+
+function filesystem_loop {
+    (
+        $1 $2
+    ) | while read fs type size used available percentage mount_point
+    do
+        # Check if mount point exists
+        if [ "$fs" = 'Filesystem' ]
+        then
+            continue
+        fi
+
+        # Check if we are in the an excluded path
+        for excluded_path in $excluded_paths
+        do
+            if echo $mount_point | grep -qE "^$excluded_path"
+            then
+                continue 2
+            fi
+        done
+
+        percentage=${percentage%\%}
+
+        check_critical_threshold
+        check_warning_threshold
+
+        if [ ! -z ${3+x} ]
+        then
+            check_inodes
+        fi
+    done
+}
+
+function main {
+    check_params
+
+    local display_free_space='df -PlTh'
+    local display_free_inodes='df -PlTi'
+
+    filesystem_loop $display_free_space
+    filesystem_loop $display_free_inodes inodes
+
+    echo 'OK'
+    exit 0
+}
+
+main


### PR DESCRIPTION
There is now a max threshold for inodes.
The default warning threshold of inodes is 20M

The new command line usage is:
```
Usage: $0 WARN_THRESHOLD CRITICAL_THRESHOLD [WARN_INODES_THRESHOLD][EXCLUDED_PATH [EXCLUDED_PATH [...]]]
```

The script was rewritten with functions.